### PR TITLE
Add new splashes to Pridepack

### DIFF
--- a/assets/minecraft/texts/splashes.txt
+++ b/assets/minecraft/texts/splashes.txt
@@ -140,7 +140,7 @@ douglas.ogg
 regina.ogg
 melancolie.ogg
 reminiscence.ogg
-Happy Pride Month 2024!
+Happy Pride Month 2025!
 ptide month!
 I think I'm gay.
 5000+ Downloads on Modrinth!
@@ -190,7 +190,7 @@ Go watch the Pridepack trailer!
 ???
 THE END IS NEVER THE END IS NEVER THE END IS NEVER
 THE CAKE IS A LIE!
-Works on 1.13-1.21.4!
+Works on 1.13-1.21.6!
 birb
 What if I just... moew :3
 Underrated!
@@ -270,3 +270,15 @@ Also try QNN!
 Also try CRSS!
 Also try Modfest!
 As seen on BlanketCon 25!
+Rebundled Bundles!
+Rainbow Chasers!
+Chase the Rainbows!
+water is so gay the harnesses changed
+Done before 1.21.6!
+Over 100 issues and PRs in GitHub!
+The sky is full of rainbows to explore!
+Now configurable with ResPackOps!
+sudo rm -rf /
+Works with Packwiz!
+Why are the paintings floating?
+June 6th 1994, Day 2546


### PR DESCRIPTION
Self explanatory.

As for what each splash is:

`Happy Pride Month 2025`
`Works on 1.13-1.21.6`
Updates for relevant dates or versions

`Rebundled Bundles`
Reference to the _new_ bundle textures from Issue 98 (PR number 99 )

`Rainbow Chasers!`
`Chase the Rainbow!`
`The sky is full of rainbows to explore!`
Reference to the Pridepack Update name

`water is so gay the harnesses changed`
Cauldrons can be used to undye items. this just pokes fun at the fact that the water is so gay that undying the harnesses made them _prideful_

`Done before 1.21.6`
We were feature complete before 1.21.6 released! (Hopefully it'll happen for 1.21.7+)

`Over 100 issues and PRs in GitHub`
As of #100 , Pridepack has had over 100 issues and PRs done

`Now configurable with ResPackOps!`
Self-explanatory

`sudo rm -rf /`
Something you should NOT run anytime soon outside a VM.

`Works with Packwiz!`
I like packwiz. And Pridepack works with it

`Why are the paintings floating?`
Originally was flying instead of floating, but pretty much just a fun poke at the fact that Pridepack has as of 9.0, 4 different paintings with flying/floating references

`June 6th 1994, Day 2546`
Reference to the show Code Lyoko - Episode 52 (Season 2 Episode 26) : The Key (you should however watch the previous ones)
Some folks there know about Pridecraft and Pridepack so I just wanted to add the reference to people who know it
The show is _not_ controversial as far as I know - It's just a fun nod to it.