### PR TITLE
feat!: Implement format changes from 25w31a

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,39 +1,29 @@
 {
   "pack": {
-    "min_format": 4,
-    "max_format": 9999,
     "pack_format": 4,
-    "supported_formats": [4, 9999],
+    "supported_formats": [4, 65],
+    "min_format": [4, 0],
+    "max_format": [9999, 0],
     "description": "§cPr§6id§eep§2ac§9k 9§5.0 §r| Chase the Rainbows!"
   },
  "overlays": {
     "entries": [
       {
-	"min_format": 16,
-	"max_format": 9999,
-        "formats": [
-          16,
-          9999
-        ],
-	
+	"min_format": [16, 0],
+	"max_format": [9999, 0],
+        "formats": [16, 65],
         "directory": "format16"
       },
       {
-	"min_format": 49,
-	"max_format": 9999,
-        "formats": [
-          49,
-          9999
-        ],
+	"min_format": [49, 0],
+	"max_format": [9999, 0],
+        "formats": [49, 65],
         "directory": "format49"
       },
       {
-	"min_format": 53,
-	"max_format": 9999,
-        "formats": [
-          53,
-          9999
-        ],
+	"min_format": [53, 0],
+	"max_format": [9999, 0],
+        "formats": [53, 65],
         "directory": "format53"
       }
     ]

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,28 +1,28 @@
 {
   "pack": {
     "min_format": 16,
-    "max_format": 65,
+    "max_format": 9999,
     "pack_format": 16,
-    "supported_formats": [16, 65],
+    "supported_formats": [16, 9999],
     "description": "§cPr§6id§eep§2ac§9k §510§r.0 | Gayme Drop 3 !\n§oBy Pridecraft Studios"
   },
  "overlays": {
     "entries": [
       {
 	      "min_format": 16,
-	      "max_format": 65,
+	      "max_format": 9999,
         "formats": [16, 64],
         "directory": "format16"
       },
       {
 	      "min_format": 49,
-	      "max_format": 65,
+	      "max_format": 9999,
         "formats": [49, 64],
         "directory": "format49"
       },
       {
 	      "min_format": 53,
-	      "max_format": 65,
+	      "max_format": 9999,
         "formats": [53, 64],
         "directory": "format53"
       }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -6,23 +6,23 @@
     "supported_formats": [16, 9999],
     "description": "§cPr§6id§eep§2ac§9k §510§r.0 | Gayme Drop 3 !\n§oBy Pridecraft Studios"
   },
- "overlays": {
+  "overlays": {
     "entries": [
       {
-	      "min_format": 16,
-	      "max_format": 9999,
+        "min_format": 16,
+        "max_format": 9999,
         "formats": [16, 64],
         "directory": "format16"
       },
       {
-	      "min_format": 49,
-	      "max_format": 9999,
+        "min_format": 49,
+        "max_format": 9999,
         "formats": [49, 64],
         "directory": "format49"
       },
       {
-	      "min_format": 53,
-	      "max_format": 9999,
+        "min_format": 53,
+        "max_format": 9999,
         "formats": [53, 64],
         "directory": "format53"
       }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,29 +1,29 @@
 {
   "pack": {
-    "pack_format": 4,
-    "supported_formats": [4, 65],
-    "min_format": [4, 0],
-    "max_format": [9999, 0],
-    "description": "§cPr§6id§eep§2ac§9k 9§5.0 §r| Chase the Rainbows!"
+    "min_format": 16,
+    "max_format": 65,
+    "pack_format": 16,
+    "supported_formats": [16, 65],
+    "description": "§cPr§6id§eep§2ac§9k §510§r.0 | Gayme Drop 3 !\n§oBy Pridecraft Studios"
   },
  "overlays": {
     "entries": [
       {
-	"min_format": [16, 0],
-	"max_format": [9999, 0],
-        "formats": [16, 65],
+	      "min_format": 16,
+	      "max_format": 65,
+        "formats": [16, 64],
         "directory": "format16"
       },
       {
-	"min_format": [49, 0],
-	"max_format": [9999, 0],
-        "formats": [49, 65],
+	      "min_format": 49,
+	      "max_format": 65,
+        "formats": [49, 64],
         "directory": "format49"
       },
       {
-	"min_format": [53, 0],
-	"max_format": [9999, 0],
-        "formats": [53, 65],
+	      "min_format": 53,
+	      "max_format": 65,
+        "formats": [53, 64],
         "directory": "format53"
       }
     ]

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,5 +1,7 @@
 {
   "pack": {
+    "min_format": 4,
+    "max_format": 9999,
     "pack_format": 4,
     "supported_formats": [4, 9999],
     "description": "§cPr§6id§eep§2ac§9k 9§5.0 §r| Chase the Rainbows!"
@@ -7,13 +9,18 @@
  "overlays": {
     "entries": [
       {
+	"min_format": 16,
+	"max_format": 9999,
         "formats": [
           16,
           9999
         ],
+	
         "directory": "format16"
       },
       {
+	"min_format": 49,
+	"max_format": 9999,
         "formats": [
           49,
           9999
@@ -21,6 +28,8 @@
         "directory": "format49"
       },
       {
+	"min_format": 53,
+	"max_format": 9999,
         "formats": [
           53,
           9999


### PR DESCRIPTION
This PR implements the new format changes introduced in [Minecraft 25w31a](https://minecraft.wiki/w/25w31a).

This does "break" compatibility with all versions before Format 16, as 25w31a requires the resource pack to use Format 16 or greater to not appear as incompatible or broken in-game.

Past versions ***__should__*** still work, but will have the pack show a red banner claiming the pack is incompatible with it anyway. This was already an issue, since before `supported_formats` was a thing, any version that uses the pack formats `>=5` and `<=15` would have the same banner.